### PR TITLE
fix: Honk for iOS Safari

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,11 @@
 const honkify = () => {
+
+  //check if the user is on iOS Safari, if they are, we initiate the safari audio "hack"
+  var ua = window.navigator.userAgent;
+  var iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
+  var webkit = !!ua.match(/WebKit/i);
+  var iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
+
   if (typeof window === 'undefined') {
     console.warn('honkify only works in the browser.');
     console.warn('I mean... honk!');
@@ -8,6 +15,20 @@ const honkify = () => {
   const audio = new Audio(
     'https://res.cloudinary.com/jlengstorf/video/upload/q_auto/v1569957993/honk-sound.mp3',
   );
+
+  /**
+   * if the platform is iOS Safari, we quickly play, pause, reset the audio object
+   * this allows it to be playable the next time an user clicks a link
+   */
+
+  if (iOSSafari) {
+    console.log('Honk! This is safari')
+    document.body.addEventListener('touchstart', () => {
+      audio.play();
+      audio.pause();
+      audio.currentTime = 0;
+    })
+  }
 
   const links = document.querySelectorAll('a');
 

--- a/index.js
+++ b/index.js
@@ -7,10 +7,10 @@ const honkify = () => {
   }
 
    //check if the user is on iOS Safari, if they are, we initiate the safari audio "hack"
-   const ua = window.navigator.userAgent;
-   const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
-   const webkit = !!ua.match(/WebKit/i);
-   const iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
+  const ua = window.navigator.userAgent;
+  const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
+  const webkit = !!ua.match(/WebKit/i);
+  const iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
 
   const audio = new Audio(
     'https://res.cloudinary.com/jlengstorf/video/upload/q_auto/v1569957993/honk-sound.mp3',

--- a/index.js
+++ b/index.js
@@ -1,16 +1,16 @@
 const honkify = () => {
 
-  //check if the user is on iOS Safari, if they are, we initiate the safari audio "hack"
-  var ua = window.navigator.userAgent;
-  var iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
-  var webkit = !!ua.match(/WebKit/i);
-  var iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
-
   if (typeof window === 'undefined') {
     console.warn('honkify only works in the browser.');
     console.warn('I mean... honk!');
     return;
   }
+
+   //check if the user is on iOS Safari, if they are, we initiate the safari audio "hack"
+   const ua = window.navigator.userAgent;
+   const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
+   const webkit = !!ua.match(/WebKit/i);
+   const iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
 
   const audio = new Audio(
     'https://res.cloudinary.com/jlengstorf/video/upload/q_auto/v1569957993/honk-sound.mp3',

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const honkify = () => {
-
   if (typeof window === 'undefined') {
     console.warn('honkify only works in the browser.');
     console.warn('I mean... honk!');


### PR DESCRIPTION
iOS Safari has this weird thing where the audio streams aren't loaded on first click. So we wait for user interaction, "play" the audio, pause it and reset the object. 

When an user actually clicks on a link, it should _HONK_